### PR TITLE
修复了MinGW环境下输出异常的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,30 @@ Licence: Apache Licene 2.0
 **(3)** 如果你需要添加新的编译工具，可以修改Makefile 的 install: 处，以 arm-linux-gcc 为例，echo 'alias arm-linux-gcc="color_compile arm-linux-gcc"' >> $(ALIAS_FILE)，或者直接修改 ~/.bashrc 都行。
 
 **(4)** 如果你需要更改显示的颜色，直接修改 out_color_info.c 源码就行，其中有一些颜色定义的宏。
+
+
+
+# 2017-02-26更新
+-------
+
+**修复了mingw下的显示异常的问题**
+
+
+由于 `linux` 和 `windows` 下snprintf返回值不同
+
+根据输出结果总结如下：
+
+1.	在 `windows` 下, 如果字符串长度大于 `count`, 函数返回 `-1` 以标志可能导致的错误, 如果字符串长度小于或者等于 `count`, 函数返回实际的字符串的长度. 在 `linux` 下, 返回实际的字符串的长度.
+
+2.	输出不同, 在 `windows` 下, 如果字符串长度大于 `count`, 会输出 `count` 个字符, 但是没有结束符, 后面的值会混乱; 如果字符串的长度等于 `count`, 输出全部字符串, 但是没有结束符, 后面的值同样很混乱; 在 `linux` 下, 永远输出 `count - 1` 个字符, 加一个结束符 '\0', 所以在本例子中, `count = 13` 时, 无论 `windows` 下还是 `linux` 下都正确.
+
+
+因此修改代码中, `snprintf` 后, 增加 buf[XXX] = '\0';
+
+
+```cpp
+snprintf(buf, mark_p - p, "%s", p + 1);
+buf[mark_p - p - 1] = '\0';
+```
+
+

--- a/color_compile.c
+++ b/color_compile.c
@@ -18,13 +18,12 @@ int main(int argc, char const *argv[])
 {
 	int i;
 	char buf[BUF_SIZE];
-
 	if (argc < 2 || 0 != strcmp(argv[0], "color_compile") )
+	if (argc < 2)
 	{
 		fprintf(stderr, "[color_compile] bad argument...\n");
 		return 1;
 	}
-
 	// declude make menuconfig
 	if (3 == argc && 0 == strcmp(argv[1], "make") && 
 	    0 == strcmp(argv[2], "menuconfig") )

--- a/out_color_info.c
+++ b/out_color_info.c
@@ -44,6 +44,9 @@
 #define TRUE	1
 #define FALSE	0
 
+
+#define index strchr
+
 struct mark_st
 {
 	const char *mark;
@@ -51,7 +54,7 @@ struct mark_st
 	const char *print_self;
 };
 
-static struct mark_st Mark[MARK_NUM] = 
+static struct mark_st Mark[MARK_NUM] =
 {
 	{WARNING,    WARNING_COLOR, WARNING_COLOR "warning" COLOR_END ":"},
 	{ERROR,      ERROR_COLOR,   ERROR_COLOR "error" COLOR_END ":"},
@@ -95,9 +98,11 @@ static void color_print_line(const char *line, const char *mark_p, int m_i)
 		// collect2: error: ld returned 1 exit status
 		p = index(line, ':');
 		snprintf(buf, p - line + 1, "%s", line);
+		buf[p - line] = '\0';
 		printf("%s%s%s%s:", PURPLE, BOLD, buf, COLOR_END);
 
 		snprintf(buf, mark_p - p, "%s", p + 1);
+		buf[mark_p - p - 1] = '\0';
 		printf("%s%s%s", Mark[m_i].color, buf, COLOR_END);
 
 		printf("%s", Mark[m_i].print_self);
@@ -109,10 +114,12 @@ static void color_print_line(const char *line, const char *mark_p, int m_i)
 		// test.c:24: 错误：‘a’未声明(在此函数内第一次使用) // centos, gcc4.2
 		filename = index(line, ':');
 		snprintf(buf, filename - line + 1, "%s", line);
+		buf[filename - line] = '\0';
 		printf("%s%s%s%s:", Mark[m_i].color, BOLD, buf, COLOR_END);
 
 		row = index(filename + 1, ':');
 		snprintf(buf, row - filename, "%s", filename + 1);
+		buf[row - filename - 1] = '\0';
 		printf("%s%s%s%s:", ROW_COLOR, BOLD, buf, COLOR_END);
 
 		snprintf(buf, mark_p - row, "%s", row + 1);
@@ -128,17 +135,21 @@ static void color_print_line(const char *line, const char *mark_p, int m_i)
 		// xx.c:11:41: fatal error: include/xx.h: No such file or directory
 		filename = index(line, ':');
 		snprintf(buf, filename - line + 1, "%s", line);
+		buf[filename - line] = '\0';
 		printf("%s%s%s%s:", Mark[m_i].color, BOLD, buf, COLOR_END);
 
 		row = index(filename + 1, ':');
 		snprintf(buf, row - filename, "%s", filename + 1);
+		buf[row - filename - 1] = '\0';
 		printf("%s%s%s%s:", ROW_COLOR, BOLD, buf, COLOR_END);
 
 		col = index(row + 1, ':');
 		snprintf(buf, col - row, "%s", row + 1);
+		buf[col - row - 1] = '\0';
 		printf("%s%s%s:", COL_COLOR, buf, COLOR_END);
 
 		snprintf(buf, mark_p - col, "%s", col + 1);
+		buf[mark_p - col - 1] = '\0';
 		printf("%s%s%s", Mark[m_i].color, buf, COLOR_END);
 
 		printf("%s", Mark[m_i].print_self);
@@ -176,10 +187,12 @@ static void color_print_make_error(const char *line, const char *p_sign)
 	if (left != NULL)
 	{
 		snprintf(buf, left - line + 1, "%s", line);
+		buf[left - line] = '\0';
 		printf("%s%s%s%s", RED, BOLD, buf, COLOR_END);
-		
+
 		right = index(left + 1, ']');
 		snprintf(buf, right - left + 2, "%s", left);
+		buf[right - left + 1] = '\0';
 		printf("%s%s%s", YELLOW, buf, COLOR_END);
 
 		printf("%s%s%s%s", RED, BOLD, right + 1, COLOR_END);
@@ -246,7 +259,7 @@ int main(void)
 			printf("%s", line);
 		}
 	}
-	
+
 	return 0;
 }
 


### PR DESCRIPTION
**修复了mingw下的显示异常的问题**


由于 `linux` 和 `windows` 下snprintf返回值不同

根据输出结果总结如下：

1.	在 `windows` 下, 如果字符串长度大于 `count`, 函数返回 `-1` 以标志可能导致的错误, 如果字符串长度小于或者等于 `count`, 函数返回实际的字符串的长度. 在 `linux` 下, 返回实际的字符串的长度.

2.	输出不同, 在 `windows` 下, 如果字符串长度大于 `count`, 会输出 `count` 个字符, 但是没有结束符, 后面的值会混乱; 如果字符串的长度等于 `count`, 输出全部字符串, 但是没有结束符, 后面的值同样很混乱; 在 `linux` 下, 永远输出 `count - 1` 个字符, 加一个结束符 '\0', 所以在本例子中, `count = 13` 时, 无论 `windows` 下还是 `linux` 下都正确.


因此修改代码中, `snprintf` 后, 增加 buf[XXX] = '\0';


```cpp
snprintf(buf, mark_p - p, "%s", p + 1);
buf[mark_p - p - 1] = '\0';
```
